### PR TITLE
feat: implement novu topics

### DIFF
--- a/lib/event.go
+++ b/lib/event.go
@@ -31,7 +31,7 @@ func (e *EventService) Trigger(ctx context.Context, eventId string, data ITrigge
 		return resp, err
 	}
 
-	err = e.client.sendRequest(req, &resp)
+	_, err = e.client.sendRequest(req, &resp)
 	if err != nil {
 		return resp, err
 	}

--- a/lib/event_test.go
+++ b/lib/event_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/novuhq/go-novu/lib"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"log"
@@ -14,6 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -72,6 +73,56 @@ func TestEventServiceTrigger_Success(t *testing.T) {
 
 	ctx := context.Background()
 	fileToStruct(filepath.Join("../testdata", "novu_send_trigger.json"), &triggerPayload)
+
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: eventService.URL})
+	_, err := c.EventApi.Trigger(ctx, novuEventId, triggerPayload)
+
+	require.Nil(t, err)
+}
+
+func TestEventServiceTriggerForTopic_Success(t *testing.T) {
+	var (
+		receivedBody         lib.ITriggerPayloadOptions
+		expectedTokenRequest lib.ITriggerPayloadOptions
+		triggerPayload       lib.ITriggerPayloadOptions
+	)
+
+	eventService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if err := json.NewDecoder(req.Body).Decode(&receivedBody); err != nil {
+			log.Printf("error in unmarshalling %+v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		t.Run("Header must contain ApiKey", func(t *testing.T) {
+			authKey := req.Header.Get("Authorization")
+			assert.True(t, strings.Contains(authKey, novuApiKey))
+			assert.True(t, strings.HasPrefix(authKey, "ApiKey"))
+		})
+
+		t.Run("URL and request method is as expected", func(t *testing.T) {
+			expectedURL := "/v1/events/trigger"
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, expectedURL, req.RequestURI)
+		})
+
+		t.Run("Request is as expected", func(t *testing.T) {
+			fileToStruct(filepath.Join("../testdata", "novu_send_trigger_topic_recipient.json"), &expectedTokenRequest)
+			assert.Equal(t, expectedTokenRequest, receivedBody)
+		})
+
+		var resp lib.EventResponse
+		fileToStruct(filepath.Join("../testdata", "novu_send_trigger_response.json"), &resp)
+
+		w.WriteHeader(http.StatusOK)
+		bb, _ := json.Marshal(resp)
+		w.Write(bb)
+	}))
+
+	defer eventService.Close()
+
+	ctx := context.Background()
+	fileToStruct(filepath.Join("../testdata", "novu_send_trigger_topic_recipient.json"), &triggerPayload)
 
 	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: eventService.URL})
 	_, err := c.EventApi.Trigger(ctx, novuEventId, triggerPayload)

--- a/lib/model.go
+++ b/lib/model.go
@@ -8,9 +8,10 @@ type GeneralError error
 const Version = "v1"
 
 const (
-	HTTPStatusOk      = 200
-	HTTPStatusCreated = 201
-	HTTPRedirectOk    = 300
+	HTTPStatusOk       = 200
+	HTTPStatusCreated  = 201
+	HTTPStatusNoChange = 204
+	HTTPRedirectOk     = 300
 )
 
 const (
@@ -40,6 +41,11 @@ type TriggerRecipientsTypeSingle interface {
 	string | SubscriberPayload
 }
 
+type TriggerTopicRecipientsTypeSingle struct {
+	TopicKey string `json:"topicKey,omitempty"`
+	Type     string `json:"type,omitempty"`
+}
+
 type SubscriberPayload struct {
 	FirstName string                 `json:"first_name,omitempty"`
 	LastName  string                 `json:"last_name,omitempty"`
@@ -50,7 +56,7 @@ type SubscriberPayload struct {
 }
 
 type TriggerRecipientsType interface {
-	TriggerRecipientsTypeSingle | TriggerRecipientsTypeArray
+	TriggerRecipientsTypeSingle | TriggerRecipientsTypeArray | TriggerTopicRecipientsTypeSingle | []TriggerTopicRecipientsTypeSingle
 }
 
 type ITriggerPayload interface {
@@ -76,4 +82,39 @@ type EventRequest struct {
 
 type SubscriberResponse struct {
 	Data interface{} `json:"data"`
+}
+
+type ListTopicsResponse struct {
+	Page       int                `json:"name"`
+	PageSize   int                `json:"pageSize"`
+	TotalCount int                `json:"totalCount"`
+	Data       []GetTopicResponse `json:"data"`
+}
+
+type GetTopicResponse struct {
+	Id             string   `json:"_id"`
+	OrganizationId string   `json:"_organizationId"`
+	EnvironmentId  string   `json:"_environmentId"`
+	Key            string   `json:"key"`
+	Name           string   `json:"name"`
+	Subscribers    []string `json:"subscribers"`
+}
+
+type ListTopicsOptions struct {
+	Page     *int    `json:"page,omitempty"`
+	PageSize *int    `json:"pageSize,omitempty"`
+	Key      *string `json:"key,omitempty"`
+}
+
+type CreateTopicRequest struct {
+	Name string `json:"name"`
+	Key  string `json:"key"`
+}
+
+type RenameTopicRequest struct {
+	Name string `json:"name"`
+}
+
+type SubscribersTopicRequest struct {
+	Subscribers []string `json:"subscribers"`
 }

--- a/lib/subscribers.go
+++ b/lib/subscribers.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 type ISubscribers interface {
@@ -33,7 +34,7 @@ func (s *SubscriberService) Identify(ctx context.Context, subscriberID string, d
 		return resp, err
 	}
 
-	err = s.client.sendRequest(req, &resp)
+	_, err = s.client.sendRequest(req, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -52,7 +53,7 @@ func (s *SubscriberService) Update(ctx context.Context, subscriberID string, dat
 		return resp, err
 	}
 
-	err = s.client.sendRequest(req, &resp)
+	_, err = s.client.sendRequest(req, &resp)
 	if err != nil {
 		return resp, err
 	}
@@ -69,7 +70,7 @@ func (s *SubscriberService) Delete(ctx context.Context, subscriberID string) (Su
 		return resp, err
 	}
 
-	err = s.client.sendRequest(req, &resp)
+	_, err = s.client.sendRequest(req, &resp)
 	if err != nil {
 		return resp, err
 	}

--- a/lib/topic.go
+++ b/lib/topic.go
@@ -1,0 +1,153 @@
+package lib
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+type ITopic interface {
+	Create(ctx context.Context, key string, name string) error
+	List(ctx context.Context, options *ListTopicsOptions) (*ListTopicsResponse, error)
+	AddSubscribers(ctx context.Context, key string, subscribers []string) error
+	RemoveSubscribers(ctx context.Context, key string, subscribers []string) error
+	Get(ctx context.Context, key string) (*GetTopicResponse, error)
+	Rename(ctx context.Context, key string, name string) (*GetTopicResponse, error)
+}
+
+type TopicService service
+
+func (t *TopicService) Create(ctx context.Context, key string, name string) error {
+	var resp interface{}
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s", "topics")
+
+	reqBody := CreateTopicRequest{
+		Name: name,
+		Key:  key,
+	}
+
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, URL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return err
+	}
+
+	httpResponse, err := t.client.sendRequest(req, &resp)
+	if err != nil {
+		return err
+	}
+
+	if httpResponse.StatusCode != HTTPStatusCreated {
+		return errors.Wrap(err, "unable to create topic")
+	}
+
+	return nil
+}
+
+func (t *TopicService) List(ctx context.Context, options *ListTopicsOptions) (*ListTopicsResponse, error) {
+	var resp ListTopicsResponse
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s", "topics")
+
+	if options == nil {
+		options = &ListTopicsOptions{}
+	}
+	queryParams, _ := json.Marshal(options)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, bytes.NewBuffer(queryParams))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = t.client.sendRequest(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (t *TopicService) AddSubscribers(ctx context.Context, key string, subscribers []string) error {
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s/%s/subscribers", "topics", key)
+
+	queryParams, _ := json.Marshal(SubscribersTopicRequest{
+		Subscribers: subscribers,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, URL, bytes.NewBuffer(queryParams))
+	if err != nil {
+		return err
+	}
+
+	_, err = t.client.sendRequest(req, nil)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TopicService) RemoveSubscribers(ctx context.Context, key string, subscribers []string) error {
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s/%s/subscribers/removal", "topics", key)
+
+	queryParams, _ := json.Marshal(SubscribersTopicRequest{
+		Subscribers: subscribers,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, URL, bytes.NewBuffer(queryParams))
+	if err != nil {
+		return err
+	}
+
+	_, err = t.client.sendRequest(req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TopicService) Get(ctx context.Context, key string) (*GetTopicResponse, error) {
+	var resp GetTopicResponse
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s/%s", "topics", key)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, bytes.NewBuffer([]byte{}))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = t.client.sendRequest(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (t *TopicService) Rename(ctx context.Context, key string, name string) (*GetTopicResponse, error) {
+	var resp GetTopicResponse
+	URL := fmt.Sprintf(t.client.config.BackendURL+"/%s/%s", "topics", key)
+
+	reqBody := RenameTopicRequest{
+		Name: name,
+	}
+
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, URL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = t.client.sendRequest(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/lib/topic_test.go
+++ b/lib/topic_test.go
@@ -1,0 +1,225 @@
+package lib_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assureRequestHeaders(t *testing.T, req *http.Request, expectedURL string, expectedMethod string) {
+	t.Run("Header must contain ApiKey", func(t *testing.T) {
+		authKey := req.Header.Get("Authorization")
+		assert.True(t, strings.Contains(authKey, novuApiKey))
+		assert.True(t, strings.HasPrefix(authKey, "ApiKey"))
+	})
+
+	t.Run("URL and request method is as expected", func(t *testing.T) {
+		assert.Equal(t, expectedMethod, req.Method)
+		assert.Equal(t, expectedURL, req.RequestURI)
+	})
+}
+
+type TestServerOptions[T any, K interface{}] struct {
+	expectedURLPath    string
+	expectedSentMethod string
+	expectedSentBody   T
+
+	responseStatusCode int
+	responseBody       K
+}
+
+func createTestServer[T any, K interface{}](t *testing.T, options TestServerOptions[T, K]) *httptest.Server {
+	var receivedBody T
+
+	eventService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assureRequestHeaders(t, req, options.expectedURLPath, options.expectedSentMethod)
+
+		if req.Body == http.NoBody {
+			assert.Empty(t, options.expectedSentBody)
+		} else {
+			if err := json.NewDecoder(req.Body).Decode(&receivedBody); err != nil {
+				log.Printf("error in unmarshalling %+v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			t.Run("Request is as expected", func(t *testing.T) {
+				assert.Equal(t, options.expectedSentBody, receivedBody)
+			})
+		}
+
+		w.WriteHeader(options.responseStatusCode)
+
+		bb, _ := json.Marshal(options.responseBody)
+		w.Write(bb)
+	}))
+	t.Cleanup(func() {
+		eventService.Close()
+	})
+
+	return eventService
+}
+
+func TestCreateTopic_Success(t *testing.T) {
+	topicName := "topic"
+	topicKey := "topicKey"
+	httpServer := createTestServer(t, TestServerOptions[lib.CreateTopicRequest, map[string]string]{
+		expectedURLPath:    "/v1/topics",
+		expectedSentMethod: http.MethodPost,
+		expectedSentBody: lib.CreateTopicRequest{
+			Name: topicName,
+			Key:  topicKey,
+		},
+		responseStatusCode: http.StatusCreated,
+		responseBody:       map[string]string{},
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	err := c.TopicsApi.Create(ctx, "topicKey", "topic")
+
+	require.NoError(t, err)
+}
+
+func TestAddSubscription_Success(t *testing.T) {
+	subs := []string{"subId"}
+	key := "topicKey"
+
+	httpServer := createTestServer(t, TestServerOptions[lib.SubscribersTopicRequest, map[string]string]{
+		expectedURLPath:    fmt.Sprintf("/v1/topics/%s/subscribers", key),
+		expectedSentMethod: http.MethodPost,
+		expectedSentBody: lib.SubscribersTopicRequest{
+			Subscribers: subs,
+		},
+		responseStatusCode: http.StatusNoContent,
+		responseBody:       map[string]string{},
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	err := c.TopicsApi.AddSubscribers(ctx, key, subs)
+
+	require.NoError(t, err)
+}
+
+func TestAddSubscriptionRemoval_Success(t *testing.T) {
+	subs := []string{"subId"}
+	key := "topicKey"
+
+	httpServer := createTestServer(t, TestServerOptions[lib.SubscribersTopicRequest, map[string]string]{
+		expectedURLPath:    fmt.Sprintf("/v1/topics/%s/subscribers/removal", key),
+		expectedSentMethod: http.MethodPost,
+		expectedSentBody: lib.SubscribersTopicRequest{
+			Subscribers: subs,
+		},
+		responseStatusCode: http.StatusNoContent,
+		responseBody:       map[string]string{},
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	err := c.TopicsApi.RemoveSubscribers(ctx, key, subs)
+
+	require.NoError(t, err)
+}
+
+func TestGetTopic_Success(t *testing.T) {
+	key := "topicKey"
+	body := map[string]string{}
+	var expectedResponse *lib.GetTopicResponse = &lib.GetTopicResponse{
+		Id:             "id",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		Key:            "topicKey",
+		Name:           "topicName",
+		Subscribers:    []string{"sibId"},
+	}
+
+	httpServer := createTestServer(t, TestServerOptions[map[string]string, *lib.GetTopicResponse]{
+		expectedURLPath:    fmt.Sprintf("/v1/topics/%s", key),
+		expectedSentMethod: http.MethodGet,
+		expectedSentBody:   body,
+		responseStatusCode: http.StatusOK,
+		responseBody:       expectedResponse,
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	resp, err := c.TopicsApi.Get(ctx, key)
+
+	require.NoError(t, err)
+	require.Equal(t, resp, expectedResponse)
+}
+
+func TestListTopics_Success(t *testing.T) {
+	body := map[string]string{}
+	var expectedResponse *lib.ListTopicsResponse = &lib.ListTopicsResponse{
+		Page:       0,
+		PageSize:   20,
+		TotalCount: 1,
+		Data: []lib.GetTopicResponse{{
+			Id:             "id",
+			OrganizationId: "orgId",
+			EnvironmentId:  "envId",
+			Key:            "topicKey",
+			Name:           "topicName",
+			Subscribers:    []string{"sibId"},
+		}},
+	}
+
+	httpServer := createTestServer(t, TestServerOptions[map[string]string, *lib.ListTopicsResponse]{
+		expectedURLPath:    "/v1/topics",
+		expectedSentMethod: http.MethodGet,
+		expectedSentBody:   body,
+		responseStatusCode: http.StatusOK,
+		responseBody:       expectedResponse,
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	resp, err := c.TopicsApi.List(ctx, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, resp, expectedResponse)
+}
+
+func TestRenameTopic_Success(t *testing.T) {
+	topicKey := "topicKey"
+	newName := "topicName"
+	body := lib.RenameTopicRequest{
+		Name: newName,
+	}
+	var expectedResponse *lib.GetTopicResponse = &lib.GetTopicResponse{
+		Id:             "id",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		Name:           newName,
+		Key:            topicKey,
+		Subscribers:    []string{"sibId"},
+	}
+
+	httpServer := createTestServer(t, TestServerOptions[lib.RenameTopicRequest, *lib.GetTopicResponse]{
+		expectedURLPath:    fmt.Sprintf("/v1/topics/%s", topicKey),
+		expectedSentMethod: http.MethodPatch,
+		expectedSentBody:   body,
+		responseStatusCode: http.StatusOK,
+		responseBody:       expectedResponse,
+	})
+
+	ctx := context.Background()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: httpServer.URL})
+	resp, err := c.TopicsApi.Rename(ctx, topicKey, newName)
+
+	require.NoError(t, err)
+	require.Equal(t, resp, expectedResponse)
+}

--- a/testdata/novu_send_trigger_topic_recipient.json
+++ b/testdata/novu_send_trigger_topic_recipient.json
@@ -1,0 +1,11 @@
+{
+  "to": {
+    "topicKey": "topicKey"
+  },
+  "payload": {
+    "name": "Hello World",
+    "organization": {
+      "logo": "https://happycorp.com/logo.png"
+    }
+  }
+}


### PR DESCRIPTION
Currently this sdk doesn't have a built-in support. In my company we selected novu as a solution, because of it's topics offering.

Adding implementation to the topics API, based on the documentation at https://docs.novu.co/api/